### PR TITLE
Add Docker CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,62 @@
+name: "Docker"
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches: ["master"]
+
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: "Test"
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set up Docker Buildx"
+        uses: docker/setup-buildx-action@v3
+
+      - name: "Build image"
+        uses: docker/build-push-action@v6
+        with:
+          context: "."
+          load: true
+          tags: "dockette/nginx:latest"
+
+      - name: "Test image"
+        run: "make test"
+
+  build:
+    name: "Build"
+    needs: ["test"]
+    uses: dockette/.github/.github/workflows/docker.yml@master
+    secrets: inherit
+    with:
+      image: "dockette/nginx"
+      tag: "latest"
+      context: "."
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/nginx"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+## Project
+
+Dockette Nginx builds `dockette/nginx`, an Nginx image with SSL, HSTS, HTTP/2-oriented configuration, custom global config includes, site fragments, and Diffie-Hellman parameter files.
+
+## Images
+
+- Default image: `dockette/nginx:latest`.
+- Build context: repository root `.` with `Dockerfile`, `nginx.conf`, `mime.types`, `conf.d/`, `site.conf.d/`, `sites.d/`, and DH parameter files.
+- Base image: `dockette/stretch`.
+- GitHub Actions tests `linux/amd64`, then publishes `linux/amd64,linux/arm64` through the shared Dockette Docker workflow on `master` and the weekly schedule.
+
+## Commands
+
+- `make build` builds `${DOCKER_IMAGE}:${DOCKER_TAG}` from `.`.
+- `make test` runs `nginx -v` and validates the generated Nginx configuration with `nginx -t`.
+- `make run` starts the image locally on `80:80` and `443:443`.
+
+## Testing Notes
+
+- Prefer `make test` after Dockerfile or Nginx configuration changes.
+- Use `make -n build test run` to dry-run command wiring without requiring Docker.
+- The smoke test requires Docker and a locally built `${DOCKER_IMAGE}:${DOCKER_TAG}` image.
+
+## Guidelines
+
+- Keep `Dockerfile`, `Makefile`, README, Nginx config files, and `.github/workflows/docker.yml` aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get dist-upgrade -y && \
                                             nginx-module-njs \
                                             gettext-base && \
     rm /etc/nginx/conf.d/default.conf && \
+    mkdir -p /etc/nginx/user.conf.d && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \
     # CLEANING PART

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build:
 .PHONY: test
 test:
 	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} nginx -v
-	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'mkdir -p /etc/nginx/user.conf.d && nginx -t'
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} nginx -t
 
 .PHONY: run
 run:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+DOCKER_IMAGE=dockette/nginx
+DOCKER_TAG?=latest
+DOCKER_PLATFORMS?=linux/amd64,linux/arm64
+
+.PHONY: build
+build:
+	docker buildx build --platform ${DOCKER_PLATFORMS} -t ${DOCKER_IMAGE}:${DOCKER_TAG} .
+
+.PHONY: test
+test:
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} nginx -v
+	docker run --rm ${DOCKER_IMAGE}:${DOCKER_TAG} sh -lc 'mkdir -p /etc/nginx/user.conf.d && nginx -t'
+
+.PHONY: run
+run:
+	docker run --rm -it -p 80:80 -p 443:443 ${DOCKER_IMAGE}:${DOCKER_TAG}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ## Default
 
-Without any volumes Nginx listen IPv4 and IPv6 on both ports 80/443 and serve 444 No content.
+Without any custom site configuration, Nginx starts with no default virtual host. Mount a server configuration into `/etc/nginx/sites.d` to listen on ports 80/443.
 
 ## Usage
 
@@ -67,11 +67,7 @@ Take a look at [nginx.conf](https://github.com/dockette/nginx/blob/master/nginx.
 
 Sites are loaded from folder `/etc/nginx/sites.d`.
 
-There are 2 sites predefined:
-
-The [default](https://github.com/dockette/nginx/blob/master/sites.d/default) returns http code 444 for every requests, it's marked as `default_server`.
-
-And the [example](https://github.com/dockette/nginx/blob/master/.examples) site.
+The image ships an empty `/etc/nginx/sites.d` folder. Example site configurations are available in [.examples/sites.d](https://github.com/dockette/nginx/tree/master/.examples/sites.d), including a 444 `default_server`, but they are not installed automatically.
 
 ### Sites config
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-# Nginx
+<h1 align=center>Dockette / Nginx</h1>
 
-Nginx with SSL / HSTS and HTTP2 module. 
+<p align=center>
+   <a href="https://github.com/dockette/nginx/actions"><img src="https://github.com/dockette/nginx/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/nginx"><img src="https://img.shields.io/docker/pulls/dockette/nginx.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
+   Nginx with SSL / HSTS and HTTP2 module.
+</p>
 
 -----
-
-[![Docker Stars](https://img.shields.io/docker/stars/dockette/nginx.svg?style=flat)](https://hub.docker.com/r/dockette/nginx/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/dockette/nginx.svg?style=flat)](https://hub.docker.com/r/dockette/nginx/)
-
-## Discussion / Help
-
-[![Join the chat](https://img.shields.io/gitter/room/dockette/dockette.svg?style=flat-square)](https://gitter.im/dockette/dockette?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 ## Default
 
@@ -19,8 +21,8 @@ Without any volumes Nginx listen IPv4 and IPv6 on both ports 80/443 and serve 44
 
 ```sh
 docker run \
-    -p 80:80 \ 
-    -p 443:433 \
+    -p 80:80 \
+    -p 443:443 \
     -v /path/to/site:/etc/nginx/sites.d/site \
     --name nginx \
     dockette/nginx:latest


### PR DESCRIPTION
What changed
- Add the Dockette Docker workflow with Test, Build, and Docs jobs.
- Add mailx-style Makefile baseline targets for build, smoke test, and run.
- Normalize README badges to the copybara style and keep Maintenance guidance.
- Add repo-local AGENTS.md and CLAUDE.md instructions.

Why
- Establish the Dockette CI rollout baseline for the nginx image with consistent badges, commands, and automation.